### PR TITLE
SFTP: Close uploaded file before reading

### DIFF
--- a/vql/tools/sftp_upload.go
+++ b/vql/tools/sftp_upload.go
@@ -195,13 +195,13 @@ func upload_SFTP(ctx context.Context, scope vfilter.Scope,
 			Error: err.Error(),
 		}, err
 	}
-	defer file.Close()
 	if _, err := file.ReadFrom(reader); err != nil {
 		return &api.UploadResponse{
 			Error: err.Error(),
 		}, err
 	}
 
+	file.Close()
 	check, err := client.Lstat(fpath)
 	if err != nil {
 		return &api.UploadResponse{


### PR DESCRIPTION
Uploaded files must be closed before calling lstat on AWS managed STFP servers to avoid errors caused by AWS limitations on reading and writing at the same time.